### PR TITLE
Improve error page style

### DIFF
--- a/edp_mvp/app/templates/error.html
+++ b/edp_mvp/app/templates/error.html
@@ -1,48 +1,13 @@
-<!DOCTYPE html>
-<html lang="es">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Error {% if status_code %}{{ status_code }}{% endif %}</title>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        background: #f8f9fa;
-        color: #333;
-        text-align: center;
-        padding: 50px;
-      }
-      .container {
-        max-width: 600px;
-        margin: auto;
-        background: #fff;
-        padding: 30px;
-        border-radius: 8px;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-      }
-      h1 {
-        font-size: 48px;
-        margin-bottom: 20px;
-      }
-      p {
-        font-size: 18px;
-        margin-bottom: 20px;
-      }
-      a {
-        color: #007bff;
-        text-decoration: none;
-        font-weight: bold;
-      }
-      a:hover {
-        text-decoration: underline;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <h1>Error {% if status_code %}{{ status_code }}{% endif %}</h1>
-      <p>{{ error_message or 'Ha ocurrido un error inesperado.' }}</p>
-      <p><a href="{{ url_for('manager.dashboard') }}">Volver al inicio</a></p>
-    </div>
-  </body>
-</html>
+{% extends 'base.html' %}
+
+{% block title %}Error {% if status_code %}{{ status_code }}{% endif %} - EDP Control{% endblock %}
+
+{% block content %}
+<div class="min-h-screen flex items-center justify-center">
+  <div class="bg-[color:var(--bg-card)] border border-[color:var(--border-color)] shadow-lg rounded-lg p-8 max-w-md text-center">
+    <h1 class="text-4xl font-bold mb-4">Error {% if status_code %}{{ status_code }}{% endif %}</h1>
+    <p class="mb-6">{{ error_message or 'Ha ocurrido un error inesperado.' }}</p>
+    <a href="{{ url_for('manager.dashboard') }}" class="text-[color:var(--accent-blue)] font-semibold hover:underline">Volver al inicio</a>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- refactor error.html to extend base layout and use Tailwind classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684091a058f48331b199d964854406e6