### PR TITLE
Implement async EDP updates

### DIFF
--- a/edp_mvp/app/static/css/styles.css
+++ b/edp_mvp/app/static/css/styles.css
@@ -318,6 +318,15 @@ body {
   border-left-color: rgba(14, 203, 140, 0.5) !important;
 }
 
+/* Indicador de fila en proceso de guardado */
+.table-row-saving {
+  opacity: 0.6;
+}
+.saving-indicator svg {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
 /* Botones de acción dentro de tablas */
 .data-table .action-link {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- make `/api/update-edp` respond quickly and process updates in a background task
- notify clients via Socket.IO when update finishes
- update dashboard rows optimistically from `modal_edp_scripts.js`
- add visual indicator while a row is saving

## Testing
- `python3 edp_mvp/test_architecture.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python3 test_services.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684672f186188331a5a727ce7a0a9211