### PR TITLE
Add profiling and caching base

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ python run.py
 
 La aplicación estará disponible en `http://127.0.0.1:5000/login`
 
+## Profiling inicial
+
+Para capturar una línea base de tiempos de respuesta se puede habilitar el
+middleware de profiling de **Werkzeug**. Establece la variable de entorno
+`ENABLE_PROFILER=1` antes de ejecutar `run.py` y se registrarán estadísticas en
+la consola durante las peticiones. Desactívalo quitando esa variable una vez
+terminadas las mediciones.
+
 ## Estructura del proyecto
 
 ```

--- a/edp_mvp/app/__init__.py
+++ b/edp_mvp/app/__init__.py
@@ -2,6 +2,12 @@ from flask import Flask
 from .config import get_config
 from flask_login import LoginManager
 from .extensions import socketio, login_manager
+import os
+
+try:
+    from werkzeug.middleware.profiler import ProfilerMiddleware
+except Exception:  # pragma: no cover - optional dependency
+    ProfilerMiddleware = None
 
 
 def create_app():
@@ -11,6 +17,9 @@ def create_app():
 
     login_manager.init_app(app)
     socketio.init_app(app)
+
+    if os.getenv("ENABLE_PROFILER") == "1" and ProfilerMiddleware:
+        app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])
 
     # Usar imports relativos (con punto) o absolutos
     from .auth.routes import auth_bp

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,3 +78,4 @@ wcwidth==0.2.13
 Werkzeug==3.1.3
 wsproto==1.2.0
 WTForms==3.2.1
+redis==5.0.4


### PR DESCRIPTION
## Summary
- integrate Werkzeug profiler instead of Flask-Profiler
- document environment variable for profiling
- remove Flask-Profiler dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6847c58d817483319076b0235573040d