### PR TITLE
Integrate Celery for async metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ python run.py
 
 La aplicación estará disponible en `http://127.0.0.1:5000/login`
 
+### Trabajos en segundo plano (Celery)
+
+Para ejecutar las tareas asíncronas y el scheduler utiliza:
+
+```bash
+celery -A edp_mvp.app.celery worker --loglevel=info
+celery -A edp_mvp.app.celery beat   --loglevel=info
+```
+
+Puedes supervisar las colas con **Flower** accediendo a `http://localhost:5555` una vez iniciado con `celery --broker=$REDIS_URL flower`.
+
 ## Profiling inicial
 
 Al ejecutar la aplicación por primera vez se activa **Flask‑Profiler** para

--- a/edp_mvp/app/__init__.py
+++ b/edp_mvp/app/__init__.py
@@ -2,7 +2,30 @@ from flask import Flask
 from .config import get_config
 from flask_login import LoginManager
 from .extensions import socketio, login_manager
+from celery import Celery
 import os
+import logging
+
+# Celery application
+celery = Celery(
+    __name__,
+    broker=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+    backend=os.getenv("REDIS_URL", "redis://localhost:6379/0"),
+)
+
+
+def init_celery(app: Flask) -> Celery:
+    """Initialize Celery with Flask context."""
+
+    celery.conf.update(app.config)
+
+    class ContextTask(celery.Task):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return super().__call__(*args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery
 
 try:
     from werkzeug.middleware.profiler import ProfilerMiddleware
@@ -61,5 +84,21 @@ def create_app():
     # Old monolithic controllers (comment out when fully migrated)
     # app.register_blueprint(controller_bp)
     # app.register_blueprint(manager_bp)
+
+    init_celery(app)
+    celery.conf.beat_schedule = {
+        "refresh-kpis": {
+            "task": "edp_mvp.app.tasks.metrics.refresh_executive_kpis",
+            "schedule": 900,
+        },
+        "refresh-kanban": {
+            "task": "edp_mvp.app.tasks.metrics.refresh_kanban_metrics",
+            "schedule": 300,
+        },
+        "refresh-cashflow": {
+            "task": "edp_mvp.app.tasks.metrics.refresh_cashflow",
+            "schedule": 3600,
+        },
+    }
 
     return app

--- a/edp_mvp/app/tasks/metrics.py
+++ b/edp_mvp/app/tasks/metrics.py
@@ -1,0 +1,63 @@
+import json
+from .. import celery
+from ..services.manager_service import ManagerService
+from ..services.analytics_service import AnalyticsService
+from ..services.cashflow_service import CashflowService
+from ..services.kanban_service import KanbanService
+from ..services.kpi_service import KPIService
+from ..repositories import _redis_client as redis_client
+
+
+@celery.task(bind=True, max_retries=3)
+def refresh_executive_kpis(self):
+    """Calculate executive KPIs and cache the result."""
+    service = ManagerService()
+    response = service.get_manager_dashboard_data()
+    data = response.data.get("executive_kpis", {}) if response.success else {}
+    if redis_client:
+        redis_client.setex("kpis:latest", 900, json.dumps(data))
+    return data
+
+
+@celery.task(bind=True, max_retries=3)
+def refresh_kanban_metrics(self):
+    """Compute Kanban metrics and cache the result."""
+    service = KanbanService()
+    response = service.get_kanban_data()
+    data = response.data if response.success else {}
+    if redis_client:
+        redis_client.setex("kanban:metrics", 300, json.dumps(data))
+    return data
+
+
+@celery.task(bind=True, max_retries=3)
+def refresh_cashflow(self):
+    """Generate cashflow forecast and cache it."""
+    service = CashflowService()
+    response = service.generar_cash_forecast()
+    data = response.data if response.success else {}
+    if redis_client:
+        redis_client.setex("cashflow:latest", 3600, json.dumps(data))
+    return data
+
+
+@celery.task(bind=True, max_retries=3)
+def refresh_global_analytics(self):
+    """Generate global analytics charts and cache them."""
+    service = AnalyticsService()
+    response = service.obtener_vista_global_encargados()
+    data = response.data if response.success else {}
+    if redis_client:
+        redis_client.setex("analytics:global", 900, json.dumps(data))
+    return data
+
+
+@celery.task(bind=True, max_retries=3)
+def refresh_all_kpis(self):
+    """Calculate full KPI set across all EDPs."""
+    service = KPIService()
+    response = service.calculate_all_kpis()
+    data = response.data if response.success else {}
+    if redis_client:
+        redis_client.setex("kpis:all", 900, json.dumps(data))
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,3 +81,5 @@ wsproto==1.2.0
 WTForms==3.2.1
 redis==5.0.4
 email_validator==2.2.0
+celery==5.3.6
+flower==2.0.1


### PR DESCRIPTION
## Summary
- integrate Celery using Redis broker and result backend
- schedule periodic metric updates via Celery Beat
- add async tasks for KPIs, Kanban, cashflow and analytics
- document how to run the worker, scheduler and Flower
- include Celery and Flower dependencies

## Testing
- `python3 test_services.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python3 status_check.py`
- `python3 import_test.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684860f4178c8331aa4436e491c694d5